### PR TITLE
fix: wire netmon achievements to event handlers

### DIFF
--- a/src/lib/achievements/wiring.ts
+++ b/src/lib/achievements/wiring.ts
@@ -56,6 +56,7 @@ export function wireAchievements(
     wireSessionTimer(mgr)
     wireSessionCost(mgr)
     wireQAReports(mgr)
+    wireNetmonEvents(mgr)
     wireProgressionEvents(mgr)
     wireAchievementReporting(mgr)
 }
@@ -738,6 +739,28 @@ function wireSessionCost(mgr: AchievementManager): void {
 function wireQAReports(mgr: AchievementManager): void {
     onAppEvent("qa:report-clicked", () => {
         mgr.earn("qa-inspector")
+    })
+}
+
+function wireNetmonEvents(mgr: AchievementManager): void {
+    // "packet-sniffing" -- Open the Network Monitor window
+    onAppEvent("netmon:opened", () => {
+        mgr.earn("packet-sniffing")
+    })
+
+    // "deep-packet-inspection" -- Expand a packet row to see details
+    onAppEvent("netmon:packet-expanded", () => {
+        mgr.earn("deep-packet-inspection")
+    })
+
+    // "unknown-host" -- Filter packets by an unknown 10.0.7.x host
+    onAppEvent("netmon:unknown-host-filtered", () => {
+        mgr.earn("unknown-host")
+    })
+
+    // "port-scan" -- Run the nmap command in terminal
+    onAppEvent("netmon:nmap-run", () => {
+        mgr.earn("port-scan")
     })
 }
 


### PR DESCRIPTION
## Summary

Fixes #72 — Packet Sniffing achievements don't trigger.

## Problem

The netmon achievements were defined in `definitions.ts` and the events were being emitted from `md.ts` (Network Monitor window) and `commands.ts` (terminal), but nothing in `wiring.ts` was listening to these events. The achievements were essentially orphaned.

## Solution

Added `wireNetmonEvents()` function to `wiring.ts` which connects the existing events to their achievement triggers:

| Event | Achievement |
|-------|-------------|
| `netmon:opened` | `packet-sniffing` |
| `netmon:packet-expanded` | `deep-packet-inspection` |
| `netmon:unknown-host-filtered` | `unknown-host` |
| `netmon:nmap-run` | `port-scan` |

## Testing

- TypeScript compiles cleanly
- Achievement manager tests pass
- Verified the pattern matches other achievement wiring (e.g., `wireQAReports`, `wirePinballEvents`)